### PR TITLE
Bugfix/tab keypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ This module is designed to be used with webpack. Below are is a sample of how to
 2. `npm test`
 
 ## History
+* 1.0.4 - Fixes the behavior of the tab key
 * 1.0.3 - Fixes the label overlapping the entered filter text on blur.
 * 1.0.2 - Fixes the broken input layout due to the `invert` feature
 * 1.0.0 - Upgrade to React 16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ship-components-tag-input",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Material Design Input and Typeahead for Tags (or \"Chips\" in Material Design speak)",
   "main": "src/index.js",
   "scripts": {

--- a/src/TagContainer.js
+++ b/src/TagContainer.js
@@ -211,10 +211,10 @@ export default class TagContainer extends React.Component {
           this.props.onEnterKey(event);
           break;
         }
-      case 9: // tab
-        event.preventDefault();
-        this.selectHighlightedItem(event);
-        break;
+      // case 9: // tab
+      //   event.preventDefault();
+      //   this.selectHighlightedItem(event);
+      //   break;
       case 38: // up
         event.preventDefault();
         if (this.state.dropdownOpen) {

--- a/src/TagContainer.js
+++ b/src/TagContainer.js
@@ -211,6 +211,10 @@ export default class TagContainer extends React.Component {
           this.props.onEnterKey(event);
           break;
         }
+        // Commented this out to fix the behavior of the tab key. 
+        // The tab keyboard event was being used to select a highlighted dropdown option. 
+        // This prevented tabbing through components in a modal form dialog.
+        // With this change tag - input will ignore tab keyboard events.
       // case 9: // tab
       //   event.preventDefault();
       //   this.selectHighlightedItem(event);

--- a/src/__tests__/tagContainer.test.js
+++ b/src/__tests__/tagContainer.test.js
@@ -240,37 +240,38 @@ describe('Component: TagContainer', () => {
   });
 
   describe('handleKeyboard Function', () => {
-    it('should pass the correct item to parent on Tab key press', () => {
-      const {
-        wrapper,
-        onSelectFn
-      } = initializeMountTagContainerComponent();
+    // This test is commented out for changes in 1.0.4. See README.md.
+    // it('should pass the correct item to parent on Tab key press', () => {
+    //   const {
+    //     wrapper,
+    //     onSelectFn
+    //   } = initializeMountTagContainerComponent();
 
-      expect(onSelectFn.mock.calls.length).toBe(0);
+    //   expect(onSelectFn.mock.calls.length).toBe(0);
 
-      // highlight an option by simulating "DOWN" key, otherwise select function will not be called.
-      wrapper
-        .instance()
-        .handleKeyboard({
-          keyCode: 40,
-          preventDefault: jest.fn(),
-          stopPropagation: jest.fn()
-        });
+    //   // highlight an option by simulating "DOWN" key, otherwise select function will not be called.
+    //   wrapper
+    //     .instance()
+    //     .handleKeyboard({
+    //       keyCode: 40,
+    //       preventDefault: jest.fn(),
+    //       stopPropagation: jest.fn()
+    //     });
 
-      wrapper
-        .instance()
-        .handleKeyboard({
-          keyCode: 9,
-          preventDefault: jest.fn(),
-          stopPropagation: jest.fn()
-        });
+    //   wrapper
+    //     .instance()
+    //     .handleKeyboard({
+    //       keyCode: 9,
+    //       preventDefault: jest.fn(),
+    //       stopPropagation: jest.fn()
+    //     });
 
-      // how to ensure certain function is passed as prop to a component
-      expect(wrapper.find('Dropdown')
-        .prop('handleKeyboard')).toBe(wrapper.instance().onKeyDown);
+    //   // how to ensure certain function is passed as prop to a component
+    //   expect(wrapper.find('Dropdown')
+    //     .prop('handleKeyboard')).toBe(wrapper.instance().onKeyDown);
 
-      expect(onSelectFn.mock.calls.length).toBe(1);
-    });
+    //   expect(onSelectFn.mock.calls.length).toBe(1);
+    // });
 
     it('should pass the correct item to parent on Enter key press', () => {
       const {


### PR DESCRIPTION
The tab keyboard event was being used to select a highlighted dropdown option. This prevented tabbing through components in a modal form dialog. With this change tag-input will ignore tab keyboard events.